### PR TITLE
Update tslint.json

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -20,6 +20,9 @@
       "one-line": false,
       "trailing-comma": false,
       "arrow-parens": false,
+      "variable-name": false,
+      "object-literal-key-quotes": false,
+      "object-literal-shorthand": false,
       "no-consecutive-blank-lines": [true, 2],
       "member-ordering": [
         true,


### PR DESCRIPTION
resolve #18 

turns off a few linting rules which are more hassle than they're worth

`variable-name` seems unncessary

`object-literal-key-quotes` causes a linting error when you try to put quotes around a reserved keyword like `default`

`object-literal-shorthand` makes stuff like:

```typescript
const testVar = 123;

const testObj = {
    testVar: testVar
}
```

not work, and instead prefers 

```typescript
const testVar = 123;

const testObj = {
    testVar
}
```

which seems unclear